### PR TITLE
Shallower recursion (SM-774)

### DIFF
--- a/lib/YAML/LoadBundle.pm
+++ b/lib/YAML/LoadBundle.pm
@@ -189,7 +189,7 @@ sub _unravel_hash {
     }
 
     for my $elt (values %$data) {
-        $elt = _unravel($elt);
+        $elt = _unravel($elt) if ref($elt);
     }
 
     return $data;

--- a/t/load_yaml.t
+++ b/t/load_yaml.t
@@ -13,6 +13,7 @@ my $yaml = <<'...';
 ---
 baroque:   gabrielli
 classical: haydn
+romantic:  false
 ...
 
 my ($fh, $file) = tmpnam();


### PR DESCRIPTION
Fixes a glitch in handling literal true/false values. (YAML::XS returns these as read-only, and YAML::LoadBundle tries unnecessarily to assign to them.)